### PR TITLE
feat: add CLI command to cleanup old chats

### DIFF
--- a/backend/cli/cmd/cleanup_chats.py
+++ b/backend/cli/cmd/cleanup_chats.py
@@ -1,0 +1,50 @@
+"""Command to delete chats older than 30 days."""
+
+from datetime import datetime, timedelta, timezone
+
+import click
+from sqlalchemy import delete
+
+from app.db.models import Chat
+from app.db.session import SessionLocal
+
+
+@click.command()
+@click.option(
+    "--days",
+    default=30,
+    help="Delete chats older than this many days (default: 30)",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Show what would be deleted without actually deleting",
+)
+def cleanup_chats(days: int, dry_run: bool):
+    """Delete chats older than specified days (default: 30)."""
+    cutoff_date = datetime.now(timezone.utc) - timedelta(days=days)
+
+    with SessionLocal() as session:
+        # Count chats to be deleted
+        old_chats = session.query(Chat).filter(Chat.created_at < cutoff_date).all()
+        count = len(old_chats)
+
+        if count == 0:
+            click.echo(f"No chats older than {days} days found.")
+            return
+
+        if dry_run:
+            click.echo(f"[DRY RUN] Would delete {count} chats older than {days} days:")
+            for chat in old_chats[:10]:  # Show first 10
+                click.echo(f"  - Chat {chat.id} created at {chat.created_at}")
+            if count > 10:
+                click.echo(f"  ... and {count - 10} more")
+        else:
+            click.echo(f"Deleting {count} chats older than {days} days...")
+
+            # Delete old chats (cascade will handle messages)
+            stmt = delete(Chat).where(Chat.created_at < cutoff_date)
+            result = session.execute(stmt)
+            session.commit()
+
+            click.echo(f"Successfully deleted {result.rowcount} chats.")

--- a/backend/cli/main.py
+++ b/backend/cli/main.py
@@ -1,5 +1,6 @@
 import click
 
+from cli.cmd.cleanup_chats import cleanup_chats
 from cli.cmd.fix_fedlex_urls import fix_fedlex_urls
 from cli.cmd.load_bge import load_bge
 from cli.cmd.load_fedlex import load_fedlex
@@ -11,6 +12,7 @@ def main():
     pass
 
 
+main.add_command(cleanup_chats)
 main.add_command(fix_fedlex_urls)
 main.add_command(load_bge)
 main.add_command(load_fedlex)


### PR DESCRIPTION
## Summary
- Add CLI command to delete chats older than a specified number of days (default: 30)
- Implements privacy policy commitment for automatic data deletion
- Ready to be used in a cronjob for scheduled cleanup

## Features
- `--days` option to configure retention period (default: 30 days)
- `--dry-run` flag to preview what would be deleted without actually deleting
- Cascade deletion automatically removes associated messages
- Clear progress feedback showing count of deleted chats

## Usage
```bash
# Delete chats older than 30 days
python -m cli.main cleanup-chats

# Dry run to preview deletions
python -m cli.main cleanup-chats --dry-run

# Custom retention period
python -m cli.main cleanup-chats --days 60

# For cronjob (runs daily at 3 AM)
0 3 * * * cd /path/to/backend && python -m cli.main cleanup-chats
```

## Test Plan
- [x] Command help text displays correctly
- [x] Dry run mode works without deleting data
- [x] Command handles case when no old chats exist
- [ ] Test actual deletion with test data
- [ ] Verify cascade deletion of messages
- [ ] Test with different --days values

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a CLI command to clean up old chat histories older than a configurable number of days (default: 30).
  * Supports a dry-run mode to preview what would be deleted, including a summary and sample of affected chats.
  * Provides clear output when no chats match and after successful deletion, including counts.
  * Available alongside existing CLI commands for easier maintenance of stored chats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->