### PR TITLE
feat: improve citation handling with document URLs and hallucination detection KOS-68

### DIFF
--- a/backend/app/ai/prompts/templates/response_de.md
+++ b/backend/app/ai/prompts/templates/response_de.md
@@ -15,11 +15,11 @@ LANGUAGE RULES:
 - Use Swiss terminology: "Velo" not "Fahrrad", "Tram" not "Strassenbahn"
 
 CITATION FORMAT WITH LINKS:
-- Use markdown links: [Artikel, Absatz und Abkürzung des Erlasses](source_url)
+- Use markdown links: [Artikel, Absatz und Abkürzung des Erlasses](#document_id)
 - Examples: 
-  - [Art. 334 Abs. 1 OR](https://www.fedlex.admin.ch/eli/cc/27/317_321_377/de#art_334)
-  - [Art. 8 ZGB](https://www.fedlex.admin.ch/eli/cc/24/233_245_233/de#art_8)
-  - [Art. 35 BV](https://www.fedlex.admin.ch/eli/cc/1999/404/de#art_35)
+  - [Art. 334 Abs. 1 OR](#87633)
+  - [Art. 8 ZGB](#85872)
+  - [Art. 35 BV](#73551)
 - Common abbreviations:
   - BV = Bundesverfassung
   - ZGB = Zivilgesetzbuch
@@ -40,4 +40,4 @@ RESPONSE STRUCTURE:
 {{ question }}
 </question>
 
-Respond in Swiss German. Make ALL legal citations clickable links using the provided URLs. Do NOT add source disclaimers.
+Respond in Swiss German. Make ALL legal citations clickable links using the document IDs. Do NOT add source disclaimers.

--- a/backend/app/ai/prompts/templates/response_en.md
+++ b/backend/app/ai/prompts/templates/response_en.md
@@ -14,11 +14,11 @@ LANGUAGE RULES:
 - Use clear and precise language
 
 CITATION FORMAT WITH LINKS:
-- Use markdown links: [Article, paragraph, and abbreviation of the decree](source_url)
+- Use markdown links: [Article, paragraph, and abbreviation of the decree](#document_id)
 - Examples:
-  - [Art. 334 para. 1 CO](https://www.fedlex.admin.ch/eli/cc/27/317_321_377/en#art_334)
-  - [Art. 8 CC](https://www.fedlex.admin.ch/eli/cc/24/233_245_233/en#art_8)
-  - [Art. 35 Cst.](https://www.fedlex.admin.ch/eli/cc/1999/404/en#art_35)
+  - [Art. 334 para. 1 CO](#87633)
+  - [Art. 8 CC](#85872)
+  - [Art. 35 Cst.](#73551)
 - Common abbreviations:
   - Cst. = Federal Constitution
   - CC = Civil Code
@@ -39,4 +39,4 @@ RESPONSE STRUCTURE:
 {{ question }}
 </question>
 
-Respond in English. Make ALL legal citations clickable links using the provided URLs. Do NOT add source disclaimers.
+Respond in English. Make ALL legal citations clickable links using the document IDs. Do NOT add source disclaimers.

--- a/backend/app/ai/prompts/templates/response_fr.md
+++ b/backend/app/ai/prompts/templates/response_fr.md
@@ -15,11 +15,11 @@ LANGUAGE RULES:
 - Use formal language appropriate for legal contexts ("vous" form)
 
 CITATION FORMAT WITH LINKS:
-- Use markdown links: [Article, alinéa et abréviation de l'acte](source_url)
+- Use markdown links: [Article, alinéa et abréviation de l'acte](#document_id)
 - Examples:
-  - [Art. 334 al. 1 CO](https://www.fedlex.admin.ch/eli/cc/27/317_321_377/fr#art_334)
-  - [Art. 8 CC](https://www.fedlex.admin.ch/eli/cc/24/233_245_233/fr#art_8)
-  - [Art. 35 Cst.](https://www.fedlex.admin.ch/eli/cc/1999/404/fr#art_35)
+  - [Art. 334 al. 1 CO](#87633)
+  - [Art. 8 CC](#85872)
+  - [Art. 35 Cst.](#73551)
 - Common abbreviations:
   - Cst. = Constitution (Federal Constitution)
   - CC = Code civil (Civil Code)
@@ -40,4 +40,4 @@ RESPONSE STRUCTURE:
 {{ question }}
 </question>
 
-Respond in Swiss French. Make ALL legal citations clickable links using the provided URLs. Do NOT add source disclaimers.
+Respond in Swiss French. Make ALL legal citations clickable links using the document IDs. Do NOT add source disclaimers.

--- a/backend/app/ai/service.py
+++ b/backend/app/ai/service.py
@@ -87,8 +87,8 @@ def format_chunks(chunks: Sequence[DocumentChunk]) -> str:
 
     for chunk in chunks:
         context += f"""\
-Article: {chunk.document.title}
-URL: {chunk.document.url}
+ID: {chunk.document.id}
+Title: {chunk.document.title}
 Content: {chunk.text}
 ---
 """

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter
 
-from app.api.routes import chats
+from app.api.routes import chats, documents
 
 api_router = APIRouter()
 api_router.include_router(chats.router)
+api_router.include_router(documents.router)

--- a/backend/app/api/routes/documents.py
+++ b/backend/app/api/routes/documents.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, HTTPException
-from openai import BaseModel
+from pydantic import BaseModel
 
 from app import crud
 from app.api.deps import SessionDep
@@ -10,7 +10,7 @@ router = APIRouter(prefix="/documents", tags=["documents"])
 class DocumentRead(BaseModel):
     id: int
     title: str
-    url: str
+    url: str | None
 
 
 @router.get("/{document_id}", response_model=DocumentRead)

--- a/backend/app/api/routes/documents.py
+++ b/backend/app/api/routes/documents.py
@@ -1,0 +1,21 @@
+from fastapi import APIRouter, HTTPException
+from openai import BaseModel
+
+from app import crud
+from app.api.deps import SessionDep
+
+router = APIRouter(prefix="/documents", tags=["documents"])
+
+
+class DocumentRead(BaseModel):
+    id: int
+    title: str
+    url: str
+
+
+@router.get("/{document_id}", response_model=DocumentRead)
+def read_document(document_id: int, db: SessionDep):
+    doc = crud.get_document(db=db, document_id=document_id)
+    if not doc:
+        raise HTTPException(status_code=404, detail="Document not found")
+    return doc

--- a/backend/app/api/routes/documents.py
+++ b/backend/app/api/routes/documents.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from app import crud
 from app.api.deps import SessionDep
@@ -8,6 +8,8 @@ router = APIRouter(prefix="/documents", tags=["documents"])
 
 
 class DocumentRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
     id: int
     title: str
     url: str | None

--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -99,3 +99,7 @@ def search_similar(
             documents.append(chunk.document)
 
     return chunks, documents
+
+
+def get_document(db: Session, document_id: int):
+    return db.scalar(select(Document).where(Document.id == document_id))

--- a/frontend/app/components/assistant-message.tsx
+++ b/frontend/app/components/assistant-message.tsx
@@ -173,7 +173,7 @@ function renderContentBlock(
 export function AssistantMessage({ message }: AssistantMessageProps) {
   // Collect all search results from search blocks
   let searchResults: SearchResult[] = [];
-  for (let block of message.content_blocks) {
+  for (let block of message.content_blocks || []) {
     if (block.type === "search") {
       searchResults.push(...block.results);
     }


### PR DESCRIPTION
## Summary
- Updated AI prompts to use document ID-based citations (#1234 format) instead of full URLs
- Modified frontend to resolve citation links to actual document URLs from search results
- Added Sentry monitoring to track when AI hallucinates non-existent document citations
- Added backend API endpoint to fetch document details by ID (fallback support)

## Changes

### Backend
- Updated AI prompts (DE, EN, FR) to instruct AI to use `#document_id` format for citations
- Modified context formatting to include document IDs instead of URLs
- Added `/documents/{id}` API endpoint to fetch document details

### Frontend
- Enhanced `AssistantMessage` component to parse citation hash links
- Resolves `#1234` citations to actual document URLs from search results
- Added Sentry tracking for hallucinated citations with context (document ID, citation text, available IDs)
- Falls back gracefully when citation not found in search results

## Benefits
- Citations now work correctly without popup blockers
- Better monitoring of AI citation accuracy
- Cleaner prompt structure using IDs instead of lengthy URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Citations in AI responses now use document IDs and resolve to clickable document links.
  - Public Documents API endpoint added to fetch document details by ID.

- Improvements
  - Assistant messages automatically link in-document citations using available search results; unmatched citations keep their original link and degrade gracefully.
  - Response metadata emphasizes document ID and title for clearer references (EN/DE/FR).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->